### PR TITLE
Fixed two lines which break the task in node v0.8.17 win

### DIFF
--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -50,9 +50,9 @@ module.exports = function(grunt) {
     for (i = 0; i < files.length; i++) {
       currFile = startDir + path.sep + files[i];
       if (!file.isMatch(exclusions, currFile)) {
-        if (file.isDir(currFile)) {
+        if (fs.statSync(currFile).isDirectory()) {
           tmpPath = path.relative(localRoot, startDir + path.sep + files[i]);
-          if (!_.has(result, tmpPath)) {
+          if (!(tmpPath in result)) {
             result[tmpPath] = [];
           }
           dirParseSync(startDir + path.sep + files[i], result);


### PR DESCRIPTION
The modified code is related to the filesystem walk.
Could not verify it on Mac; on Windows, it fixes grunt-ftp-deploy functionality.
