### PR TITLE
Use `host` as default value for `authKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The parameters in our configuration are:
 
 - **host** - the name or the IP address of the server we are deploying to
 - **port** - the port that the _ftp_ service is running on
-- **authKey** - a key for looking up the saved credentials
+- **authKey** - a key for looking up the saved credentials. If no value is defined, the `host` parameter will be used
 - **src** - the source location, the local folder that we are transferring to the server
 - **dest** - the destination location, the folder on the server we are deploying to
 - **exclusions** - an optional parameter allowing us to exclude files and folders by utilizing grunt's support for `minimatch`. Please note that the definitions should be relative to the project root.

--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -151,7 +151,7 @@ module.exports = function(grunt) {
 
     localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;
     remoteRoot = Array.isArray(this.data.dest) ? this.data.dest[0] : this.data.dest;
-    authVals = getAuthByKey(this.data.auth.authKey);
+    authVals = this.data.auth.authKey ? getAuthByKey(this.data.auth.authKey) : getAuthByKey(this.data.auth.host);
     exclusions = this.data.exclusions || [];
     ftp.useList = true;
     toTransfer = dirParseSync(localRoot);


### PR DESCRIPTION
This way, one can just use the hostname on .ftppass, like so:

Gruntfile.js

```
ftp-deploy': {
  build: {
    auth: { host: 'somehost.com', port: 21 }
}}
```

.ftppass

```
{
  "somehost.com": {
    "username": "someusername",
    "password": "somepassword"
}}
```
