### PR TITLE
Handle jsftp socket errors.

### DIFF
--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -147,7 +147,8 @@ module.exports = function(grunt) {
     // Init
     ftp = new Ftp({
       host: this.data.auth.host,
-      port: this.data.auth.port
+      port: this.data.auth.port,
+      onError: done
     });
 
     localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;


### PR DESCRIPTION
Hi,

I've added handling of socket errors thrown by jsftp. This fails the task in case of a mistyped host, timeout or a similar error.
- Dali
