### PR TITLE
Enable Grunt Templates in Src Parameter

### DIFF
--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -34,6 +34,7 @@ module.exports = function (grunt) {
     var i;
     var tmpPath;
     var currFile;
+    var startDir = grunt.template.process(startDir);
 
     // initialize the `result` object if it is the first iteration
     if (result === undefined) {


### PR DESCRIPTION
_My first open source contribution ever so forgive me if I'm not doing this right._

I tried passing a grunt template variable to src paramater and got this error: 
**"<%= path %> is not an existing location"**. 

Also tried using `grunt.template.process()` but that didn't work either.

I think being able to process template variables would help with writing cleaner code. I'd set the ftp build path in a variable and every plugin and task uses the variable either directly or in the worst case scenario I use grunt.template.process().

**I looked in** `tasks/ftp-deploy.js`, **spotted the function that processes the source path on line 32 and figured it's possible to build in** `grunt.template.process()` **before the** `startDir` **check on line 45 to enable template processing without breaking backwards compatibility.** 

Hope this is a useful pull request.

_Bear in mind I'm really new to open source, so this might be a completely naive attempt at adding value to your package._
