### PR TITLE
Update README.md to better reflect the exclusion of sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use this task you will need to include the following configuration in your _g
     },
     src: 'path/to/source/folder',
     dest: '/path/to/destination/folder',
-    exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'dist/tmp']
+    exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'path/to/source/folder/dist/tmp']
   }
 }
 ```


### PR DESCRIPTION
Changes `dist/tmp` to `path/to/source/folder/dist/tmp` in the exclusions usage example.

Not prefixing the subdirectory with `path/to/source/folder/` will cause the exclusion to fail.

See issue #50 for further discussion.
