### PR TITLE
Bumped dependencies and updated license key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,21 +14,14 @@
   "bugs": {
     "url": "https://github.com/zonak/grunt-ftp-deploy/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/zonak/grunt-ftp-deploy/blob/master/LICENSE-MIT"
-    }
-  ],
   "engines": {
     "node": "*"
   },
   "dependencies": {
     "prompt": "^0.2.13",
     "jsftp": "^1.3.1",
-    "grunt": "^0.4.2",
-    "lodash": "^2.4.1",
-    "async": "^0.9.0"
+    "lodash": "^3.9.3",
+    "async": "^1.2.1"
   },
   "devDependencies": {
     "grunt": "^0.4.2",
@@ -41,5 +34,6 @@
   },
   "keywords": [
     "gruntplugin"
-  ]
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
The key `licenses` in `package.json` is now deprecated for `license`. Plus some regular bumped dependencies.
