### PR TITLE
Pass functions into src and dest options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ To use this task you will need to include the following configuration in your _g
 
 Please note that when defining paths for sources, destinations, exclusions e.t.c they need to be defined having the root of the project as a reference point.
 
+You may optionally use a function to define `src` or `dest`. For example:
+
+```javascript
+'ftp-deploy': {
+  build: {
+    auth: {
+      host: 'server.com',
+      port: 21,
+      authKey: 'key1'
+    },
+    src: function(language) {
+        language = language || 'english';
+        return 'build/' + language;
+    },
+    dest: '/path/to/destination/folder',
+    exclusions: ['path/to/source/folder/**/.DS_Store', 'path/to/source/folder/**/Thumbs.db', 'path/to/dist/tmp']
+  }
+}
+```
+The parameter can be passed like so:
+
+```shell
+grunt ftp-deploy:build:english
+```
+
+These functions can accept any number of parameters.
+
 The parameters in our configuration are:
 
 - **host** - the name or the IP address of the server we are deploying to
@@ -87,7 +114,9 @@ The task prompts for credentials that are not found in the credentials file and 
 This task is built by taking advantage of the great work of Sergi Mansilla and his [jsftp](https://github.com/sergi/jsftp) _node.js_ module and suited for the **0.4.x** branch of _grunt_.
 
 ## Release History
-
+ * 2015-07-05    v0.2.0
+    - Added ability to use functions for `src` and `dest` options.
+    - Added remote path to verbose logging.
  * 2015-02-04    v0.1.10   An option to force output verbosity.
  * 2014-10-22    v0.1.9    Log successful uploads only in verbose mode.
  * 2014-10-13    v0.1.8    Allow empty strings to be used as login details.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ftp-deploy",
   "description": "Deployment over FTP",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "homepage": "https://github.com/zonak/grunt-ftp-deploy",
   "author": {
     "name": "Zoran Nakev",
@@ -24,11 +24,12 @@
     "node": "*"
   },
   "dependencies": {
-    "prompt": "^0.2.13",
-    "jsftp": "^1.3.1",
+    "async": "^0.9.0",
+    "chalk": "^1.0.0",
     "grunt": "^0.4.2",
+    "jsftp": "^1.3.1",
     "lodash": "^2.4.1",
-    "async": "^0.9.0"
+    "prompt": "^0.2.13"
   },
   "devDependencies": {
     "grunt": "^0.4.2",

--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -7,208 +7,227 @@
 // Dependencies: jsftp
 //
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
-  grunt.util = grunt.util || grunt.utils;
+    grunt.util = grunt.util || grunt.utils;
 
-  var async = require('async');
-  var log = grunt.log;
-  var verbose = grunt.verbose;
-  var _ = require('lodash');
-  var file = grunt.file;
-  var fs = require('fs');
-  var path = require('path');
-  var Ftp = require('jsftp');
-  var prompt = require('prompt');
+    var async = require('async');
+    var log = grunt.log;
+    var verbose = grunt.verbose;
+    var _ = require('lodash');
+    var file = grunt.file;
+    var fs = require('fs');
+    var path = require('path');
+    var Ftp = require('jsftp');
+    var prompt = require('prompt');
 
-  var toTransfer;
-  var ftp;
-  var localRoot;
-  var remoteRoot;
-  var currPath;
-  var authVals;
-  var exclusions;
-  var forceVerbose;
+    var toTransfer;
+    var ftp;
+    var localRoot;
+    var remoteRoot;
+    var currPath;
+    var authVals;
+    var exclusions;
+    var forceVerbose;
 
-  // A method for parsing the source location and storing the information into a suitably formated object
-  function dirParseSync (startDir, result) {
-    var files;
-    var i;
-    var tmpPath;
-    var currFile;
+    // A method for parsing the source location and storing the information into a suitably formated object
+    function dirParseSync(startDir, result) {
+        var files;
+        var i;
+        var tmpPath;
+        var currFile;
 
-    // initialize the `result` object if it is the first iteration
-    if (result === undefined) {
-      result = {};
-      result[path.sep] = [];
-    }
-
-    // check if `startDir` is a valid location
-    if (!fs.existsSync(startDir)) {
-      grunt.warn(startDir + ' is not an existing location');
-    }
-
-    // iterate throught the contents of the `startDir` location of the current iteration
-    files = fs.readdirSync(startDir);
-    for (i = 0; i < files.length; i++) {
-      currFile = startDir + path.sep + files[i];
-      if (!file.isMatch({matchBase: true}, exclusions, currFile)) {
-        if (file.isDir(currFile)) {
-          tmpPath = path.relative(localRoot, startDir + path.sep + files[i]);
-          if (!_.has(result, tmpPath)) {
-            result[tmpPath] = [];
-          }
-          dirParseSync(startDir + path.sep + files[i], result);
-        } else {
-          tmpPath = path.relative(localRoot, startDir);
-          if (!tmpPath.length) {
-            tmpPath = path.sep;
-          }
-          result[tmpPath].push(files[i]);
-        }
-      }
-    }
-
-    return result;
-  }
-
-  // A method for changing the remote working directory and creating one if it doesn't already exist
-  function ftpCwd (inPath, cb) {
-    ftp.raw.cwd(inPath, function (err) {
-      if(err){
-        ftp.raw.mkd(inPath, function (err) {
-          if(err) {
-            log.error('Error creating new remote folder ' + inPath + ' --> ' + err);
-            cb(err);
-          } else {
-            log.ok('New remote folder created ' + inPath.yellow);
-            ftpCwd(inPath, cb);
-          }
-        });
-      } else {
-        cb(null);
-      }
-    });
-  }
-
-  // A method for uploading a single file
-  function ftpPut (inFilename, done) {
-    var fpath = path.normalize(localRoot + path.sep + currPath + path.sep + inFilename);
-    ftp.put(fpath, inFilename, function (err) {
-      if (err) {
-        log.error('Cannot upload file: ' + inFilename + ' --> ' + err);
-        done(err);
-      } else {
-        if (forceVerbose) {
-          log.ok('Uploaded file: ' + inFilename.green + ' to: ' + currPath.yellow);
-        } else {
-          verbose.ok('Uploaded file: ' + inFilename.green + ' to: ' + currPath.yellow);
-        }
-        done(null);
-      }
-    });
-  }
-
-  // A method that processes a location - changes to a folder and uploads all respective files
-  function ftpProcessLocation (inPath, cb) {
-    if (!toTransfer[inPath]) {
-      cb(new Error('Data for ' + inPath + ' not found'));
-    }
-
-    ftpCwd(path.normalize('/' + remoteRoot + '/' + inPath).replace(/\\/gi, '/'), function (err) {
-      var files;
-
-      if (err) {
-        grunt.warn('Could not switch to remote folder!');
-      }
-
-      currPath = inPath;
-      files = toTransfer[inPath];
-
-      async.eachSeries(files, ftpPut, function (err) {
-        if (err) {
-          grunt.warn('Failed uploading files!');
-        }
-        cb(null);
-      });
-    });
-  }
-
-  function getAuthVals(inAuth) {
-    var tmpData;
-    var authFile = path.resolve(inAuth.authPath || '.ftppass');
-
-    // If authentication values are provided in the grunt file itself
-    var username = inAuth.username;
-    var password = inAuth.password;
-    if (typeof username != 'undefined' && username != null && typeof password != 'undefined' && password != null) return {
-      username: username,
-      password: password
-    };
-
-    // If there is a valid auth file provided
-    if (fs.existsSync(authFile)) {
-      tmpData = JSON.parse(grunt.file.read(authFile));
-      if (inAuth.authKey) return tmpData[inAuth.authKey] || {};
-      if (inAuth.host) return tmpData[inAuth.host] || {};
-    } else if (inAuth.authKey) grunt.warn('\'authKey\' configuration provided but no valid \'.ftppass\' file found!');
-
-    return {};
-  }
-
-  // The main grunt task
-  grunt.registerMultiTask('ftp-deploy', 'Deploy code over FTP', function () {
-    var done = this.async();
-
-    // Init
-    ftp = new Ftp({
-      host: this.data.auth.host,
-      port: this.data.auth.port,
-      onError: done
-    });
-
-    localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;
-    remoteRoot = Array.isArray(this.data.dest) ? this.data.dest[0] : this.data.dest;
-    authVals = getAuthVals(this.data.auth);
-    exclusions = this.data.exclusions || [];
-    ftp.useList = true;
-    toTransfer = dirParseSync(localRoot);
-    forceVerbose = this.data.forceVerbose === true ? true : false;
-
-    // Getting all the necessary credentials before we proceed
-    var needed = {properties: {}};
-    if (!authVals.username) needed.properties.username = {};
-    if (!authVals.password) needed.properties.password = {hidden:true};
-    prompt.get(needed, function (err, result) {
-      if (err) {
-        grunt.warn('Authentication ' + err);
-      }
-      if (result.username) authVals.username = result.username;
-      if (result.password) authVals.password = result.password;
-
-      // Authentication and main processing of files
-      ftp.auth(authVals.username, authVals.password, function (err) {
-        var locations = _.keys(toTransfer);
-        if (err) {
-          grunt.warn('Authentication ' + err);
+        // initialize the `result` object if it is the first iteration
+        if (result === undefined) {
+            result = {};
+            result[path.sep] = [];
         }
 
-        // Iterating through all location from the `localRoot` in parallel
-        async.eachSeries(locations, ftpProcessLocation, function () {
-          ftp.raw.quit(function (err) {
-            if (err) {
-              log.error(err);
-            } else {
-              log.ok('FTP upload done!');
+        // check if `startDir` is a valid location
+        if (!fs.existsSync(startDir)) {
+            grunt.warn(startDir + ' is not an existing location');
+        }
+
+        // iterate throught the contents of the `startDir` location of the current iteration
+        files = fs.readdirSync(startDir);
+        for (i = 0; i < files.length; i++) {
+            currFile = startDir + path.sep + files[i];
+
+            if (!file.isMatch({
+                    matchBase: true
+                }, exclusions, currFile)) {
+                if (file.isDir(currFile)) {
+                    tmpPath = path.relative(localRoot, startDir + path.sep + files[i]);
+                    if (!_.has(result, tmpPath)) {
+                        result[tmpPath] = [];
+                    }
+                    dirParseSync(startDir + path.sep + files[i], result);
+                } else {
+                    tmpPath = path.relative(localRoot, startDir);
+                    if (!tmpPath.length) {
+                        tmpPath = path.sep;
+                    }
+                    result[tmpPath].push(files[i]);
+                }
             }
-            done();
-          });
-        });
-      });
+        }
 
-      if (grunt.errors) {
-        return false;
-      }
+        return result;
+    }
+
+    // A method for changing the remote working directory and creating one if it doesn't already exist
+    function ftpCwd(inPath, cb) {
+        ftp.raw.cwd(inPath, function(err) {
+            if (err) {
+                ftp.raw.mkd(inPath, function(err) {
+                    if (err) {
+                        log.error('Error creating new remote folder ' + inPath + ' --> ' + err);
+                        cb(err);
+                    } else {
+                        log.ok('New remote folder created ' + inPath.yellow);
+                        ftpCwd(inPath, cb);
+                    }
+                });
+            } else {
+                cb(null);
+            }
+        });
+    }
+
+    // A method for uploading a single file
+    function ftpPut(inFilename, done) {
+        var fpath = path.normalize(localRoot + path.sep + currPath + path.sep + inFilename);
+        ftp.put(fpath, inFilename, function(err) {
+            if (err) {
+                log.error('Cannot upload file: ' + inFilename + ' --> ' + err);
+                done(err);
+            } else {
+                if (forceVerbose) {
+                    log.ok('Uploaded file: ' + inFilename.green + ' to: ' + path.normalize('/' + remoteRoot + '/' + inFilename).replace(/\\/gi, '/').yellow);
+                } else {
+                    verbose.ok('Uploaded file: ' + inFilename.green + ' to: ' + path.normalize('/' + remoteRoot + '/' + inFilename).replace(/\\/gi, '/').yellow);
+                }
+                done(null);
+            }
+        });
+    }
+
+    // A method that processes a location - changes to a folder and uploads all respective files
+    function ftpProcessLocation(inPath, cb) {
+
+        if (!toTransfer[inPath]) {
+            cb(new Error('Data for ' + inPath + ' not found'));
+        }
+
+        ftpCwd(path.normalize('/' + remoteRoot + '/' + inPath).replace(/\\/gi, '/'), function(err) {
+            var files;
+
+            if (err) {
+                grunt.warn('Could not switch to remote folder!');
+            }
+
+            currPath = inPath;
+            files = toTransfer[inPath];
+
+
+            async.eachSeries(files, ftpPut, function(err) {
+                if (err) {
+                    grunt.warn('Failed uploading files!');
+                }
+                cb(null);
+            });
+        });
+    }
+
+    function getAuthVals(inAuth) {
+        var tmpData;
+        var authFile = path.resolve(inAuth.authPath || '.ftppass');
+
+        // If authentication values are provided in the grunt file itself
+        var username = inAuth.username;
+        var password = inAuth.password;
+        if (typeof username != 'undefined' && username != null && typeof password != 'undefined' && password != null) return {
+            username: username,
+            password: password
+        };
+
+        // If there is a valid auth file provided
+        if (fs.existsSync(authFile)) {
+            tmpData = JSON.parse(grunt.file.read(authFile));
+            if (inAuth.authKey) return tmpData[inAuth.authKey] || {};
+            if (inAuth.host) return tmpData[inAuth.host] || {};
+        } else if (inAuth.authKey) grunt.warn('\'authKey\' configuration provided but no valid \'.ftppass\' file found!');
+
+        return {};
+    }
+
+    // The main grunt task
+    grunt.registerMultiTask('ftp-deploy', 'Deploy code over FTP', function() {
+        var done = this.async();
+
+        // Init
+        ftp = new Ftp({
+            host: this.data.auth.host,
+            port: this.data.auth.port,
+            onError: done
+        });
+
+        localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;
+        if (_.isFunction(localRoot)) {
+            localRoot = localRoot.apply(null, Array.prototype.slice.call(arguments));
+        }
+
+        remoteRoot = Array.isArray(this.data.dest) ? this.data.dest[0] : this.data.dest;
+        if (_.isFunction(remoteRoot)) {
+            remoteRoot = remoteRoot.apply(null, Array.prototype.slice.call(arguments));
+        }
+
+        authVals = getAuthVals(this.data.auth);
+        exclusions = this.data.exclusions || [];
+        ftp.useList = true;
+        toTransfer = dirParseSync(localRoot);
+        forceVerbose = this.data.forceVerbose === true ? true : false;
+
+        // Getting all the necessary credentials before we proceed
+        var needed = {
+            properties: {}
+        };
+        if (!authVals.username) needed.properties.username = {};
+        if (!authVals.password) needed.properties.password = {
+            hidden: true
+        };
+        prompt.get(needed, function(err, result) {
+            if (err) {
+                grunt.warn('Authentication ' + err);
+            }
+            if (result.username) authVals.username = result.username;
+            if (result.password) authVals.password = result.password;
+
+            // Authentication and main processing of files
+            ftp.auth(authVals.username, authVals.password, function(err) {
+                var locations = _.keys(toTransfer);
+
+                if (err) {
+                    grunt.warn('Authentication ' + err);
+                }
+
+                log.ok('Connected to host');
+                // Iterating through all location from the `localRoot` in parallel
+                async.eachSeries(locations, ftpProcessLocation, function() {
+                    ftp.raw.quit(function(err) {
+                        if (err) {
+                            log.error(err);
+                        } else {
+                            log.ok('FTP upload done!');
+                        }
+                        done();
+                    });
+                });
+            });
+
+            if (grunt.errors) {
+                return false;
+            }
+        });
     });
-  });
 };


### PR DESCRIPTION
This allows you to pass functions into `src` and `dest` options.

As I feel this is an additional feature, not a bug fix, I have changed the version to 0.2.0.