### PR TITLE
Fix deprecation warnings that shows up in console.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: node_js
 before_install:
   - "npm install -g grunt-cli"
 node_js:
-  - "0.11"
-  - "0.10"
+  - "8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prompt": "^0.2.13",
-    "jsftp": "^1.3.1",
+    "jsftp": "^2.0.0",
     "grunt": "^0.4.2",
     "lodash": "^2.4.1",
     "async": "^0.9.0"

--- a/tasks/ftp-deploy.js
+++ b/tasks/ftp-deploy.js
@@ -74,9 +74,9 @@ module.exports = function (grunt) {
 
   // A method for changing the remote working directory and creating one if it doesn't already exist
   function ftpCwd (inPath, cb) {
-    ftp.raw.cwd(inPath, function (err) {
+    ftp.raw('cwd', inPath, function (err) {
       if(err){
-        ftp.raw.mkd(inPath, function (err) {
+        ftp.raw('mkd', inPath, function (err) {
           if(err) {
             log.error('Error creating new remote folder ' + inPath + ' --> ' + err);
             cb(err);
@@ -195,7 +195,7 @@ module.exports = function (grunt) {
 
         // Iterating through all location from the `localRoot` in parallel
         async.eachSeries(locations, ftpProcessLocation, function () {
-          ftp.raw.quit(function (err) {
+          ftp.raw('quit', function (err) {
             if (err) {
               log.error(err);
             } else {


### PR DESCRIPTION
This PR is to address issue https://github.com/zonak/grunt-ftp-deploy/issues/117

Note that upgrading jsftp to ^2.0.0 is mandatory to fix all the warnings showing up in console.